### PR TITLE
Removed SetConnMaxLifetime

### DIFF
--- a/{{ cookiecutter.app_name }}/internal/{{ cookiecutter.main_domain }}/repository/repository.go
+++ b/{{ cookiecutter.app_name }}/internal/{{ cookiecutter.main_domain }}/repository/repository.go
@@ -46,7 +46,6 @@ func New(ctx context.Context, cfg *settings.Settings) (repo {{ cookiecutter.main
 
 		mysqlConn.SetMaxOpenConns(25) // Set some limits for connection pool
 		mysqlConn.SetMaxIdleConns(15)
-		mysqlConn.SetConnMaxLifetime(5 * time.Minute)
 
 		err = mysqlConn.Ping()
 		if err != nil {


### PR DESCRIPTION
Removed the line because it causes killing healthy connections
https://github.blog/2020-05-20-three-bugs-in-the-go-mysql-driver/